### PR TITLE
chore: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
     name: PHP ${{ matrix.php }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip


### PR DESCRIPTION
## Summary

- Pins all `uses:` references in GitHub Actions workflows to full 40-character commit SHAs
- Prevents supply chain attacks via mutable action tags (tag hijacking)
- Original tag/branch references are preserved as inline comments for readability

## Test plan

- [ ] Verify workflows still trigger correctly after merge
- [ ] Confirm no workflow syntax errors (check Actions tab)
- [ ] Validate pinned SHAs match the expected tag versions via comments